### PR TITLE
feat(CZ): use DIN 1451 font for Czech license plates

### DIFF
--- a/src/components/LicensePlate.tsx
+++ b/src/components/LicensePlate.tsx
@@ -228,7 +228,7 @@ const LicensePlate = forwardRef<HTMLDivElement, LicensePlateProps>(
       if (country === 'S') return 'Tratex, Normal';
       if (country === 'N') return 'MyriadPro, sans-serif';
       if (country === 'GB') return 'UKNumberPlate, sans-serif';
-      if (country === 'A') return '"Alte DIN 1451", sans-serif';
+      if (country === 'A' || country === 'CZ') return '"Alte DIN 1451", sans-serif';
       return 'EuroPlate, sans-serif';
     };
     


### PR DESCRIPTION
## Summary
- Add Czech Republic (CZ) to use the authentic DIN 1451 Mittelschrift font
- Uses the existing `AlteDIN1451.ttf` font that is already used for Austria

Closes #4

## Test plan
- [x] Select Czech Republic (CZ) as the country
- [x] Verify the license plate text renders with DIN 1451 font

🤖 Generated with [Claude Code](https://claude.com/claude-code)